### PR TITLE
feat(ci): Make GCC builds non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
   build-test-linux:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow_failure || false }}
     container:
       image: 'ghcr.io/monamimani-builds/cpp-devcontainer:latest'
     strategy:
@@ -93,18 +94,23 @@ jobs:
           - os: ubuntu-latest
             configure-preset: "Linux-Clang-Ninja-Debug"
             build-preset: "Linux-Clang-Ninja-Debug"
+            allow_failure: false
           - os: ubuntu-latest
             configure-preset: "Linux-Clang-Ninja-Release"
             build-preset: "Linux-Clang-Ninja-Release"
+            allow_failure: false
           - os: ubuntu-latest
             configure-preset: "Linux-Gcc-Ninja-Debug"
             build-preset: "Linux-Gcc-Ninja-Debug"
+            allow_failure: true
           - os: ubuntu-latest
             configure-preset: "Linux-Gcc-Ninja-Release"
             build-preset: "Linux-Gcc-Ninja-Release"
+            allow_failure: true
           - os: ubuntu-latest
             configure-preset: "Linux-Clang-NinjaMultiConfig"
             build-preset: "Linux-Clang-NinjaMultiConfig-Debug"
+            allow_failure: false
 
     name: ${{matrix.build-preset}}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
   build-test-linux:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow_failure }}
     container:
       image: 'ghcr.io/monamimani-builds/cpp-devcontainer:latest'
     strategy:
@@ -149,7 +150,6 @@ jobs:
     #     generator: ${{ matrix.generator }}
 
     - name: "[Linux] CMake Configure & Build"
-      continue-on-error: ${{ matrix.allow_failure }}
       if: runner.os == 'Linux'
       run: |
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   build-test-linux:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow_failure || false }}
+    continue-on-error: ${{ matrix.allow_failure }}
     container:
       image: 'ghcr.io/monamimani-builds/cpp-devcontainer:latest'
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,6 @@ jobs:
   build-test-linux:
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow_failure }}
     container:
       image: 'ghcr.io/monamimani-builds/cpp-devcontainer:latest'
     strategy:
@@ -150,6 +149,7 @@ jobs:
     #     generator: ${{ matrix.generator }}
 
     - name: "[Linux] CMake Configure & Build"
+      continue-on-error: ${{ matrix.allow_failure }}
       if: runner.os == 'Linux'
       run: |
 


### PR DESCRIPTION
This change modifies the GitHub Actions workflow to prevent GCC build failures from stopping the entire CI run.

An `allow_failure` variable is introduced in the Linux build matrix. This variable is set to `true` for GCC builds and `false` for others. The `continue-on-error` property of the job is then set based on this matrix variable.

This addresses issue #5, which requested that GCC builds be non-blocking to allow for the visibility of errors without halting other successful build jobs.